### PR TITLE
Allow cleartext communication with Android emulator host device

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -2,6 +2,6 @@
 
     <!-- Temporarily added in order to support cleartext targeting Android P -->
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">localhost</domain>
+        <domain includeSubdomains="true">10.0.2.2</domain>
     </domain-config>
 </network-security-config>


### PR DESCRIPTION
This makes the repo work out of the box with the Android emulator.
Tested on Android 8.1/9/10.