### PR TITLE
Update Operation and Type constants to match PySyft-Proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ The Android Worker is an app that connects to a PySyft worker and performs the o
 * To run the setup locally, it is better to use an Android emulator
 
 ## PySfyt Version
-This app has been tested with PySyft 0.1.25a and PyGrid commit 694c01d1ecebfa891ef443e68594f07dd382abff
+This app has been tested with PySyft 0.2.0a2 and PyGrid commit 8f990d9790899c87323a9dc82381b8811439f809
 
 

--- a/app/src/main/java/com/mccorby/openmined/worker/datasource/mapper/Mappers.kt
+++ b/app/src/main/java/com/mccorby/openmined/worker/datasource/mapper/Mappers.kt
@@ -31,19 +31,19 @@ internal object CompressionConstants {
 
 // Operations in PySyft
 internal object OperationConstants {
-    internal const val CMD = 26
-    internal const val OBJ = 27
-    internal const val OBJ_REQ = 28
+    internal const val CMD = 33
+    internal const val OBJ = 34
+    internal const val OBJ_REQ = 35
     internal const val OBJ_DEL = 4
-    internal const val FORCE_OBJ_DEL = 31
+    internal const val FORCE_OBJ_DEL = 38
 }
 
 // Types are encoded in the stream sent from PySyft
 internal object TypeConstants {
     const val TYPE_TUPLE = 6
     const val TYPE_LIST = 1
-    const val TYPE_TENSOR = 13
-    const val TYPE_TENSOR_POINTER = 20
+    const val TYPE_TENSOR = 14
+    const val TYPE_TENSOR_POINTER = 25
 }
 
 // Commands


### PR DESCRIPTION
This is enough to get the `Socket Bob` example notebook running with the
current `dev` versions of PySyft/PyGrid. It suggests a few pieces of
further work:
* Refactoring to pull the constants directly from `proto.json`
* Reworking deletion (since I think maybe DeleteMessage has been removed)
* Expanding the set of supported messages and types

Baby steps though, right?