### PR TITLE
Update the README to include a commit SHA for PySyft 0.2.0a2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ The Android Worker is an app that connects to a PySyft worker and performs the o
 * To run the setup locally, it is better to use an Android emulator
 
 ## PySyft Version
-This app has been tested with PySyft 0.2.0a2 and PyGrid commit 8f990d9790899c87323a9dc82381b8811439f809
+This app has been tested with PySyft 0.2.0a2 (b0b8a135) and PyGrid commit 8f990d97
 
 


### PR DESCRIPTION
Some recent versions don't have tags or releases, which makes this
version harder to find by number than by SHA.