### PR TITLE
Extract connection details to a local properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,10 @@ The Android Worker is an app that connects to a PySyft worker and performs the o
 
 * Start the socket server
   * There is an example provided in the code of PyGrid: [`socketio_server_demo.py`](https://github.com/OpenMined/PyGrid/blob/dev/examples/android/socketio_server_demo.py)
+* Edit the file `local_connection.properties` in the Android project to match the IP address of the machine running the socket server.
+  * If using the emulator, this address should be `10.0.2.2`
 * Start the Android application
-  * If you're running the application on a physical device (instead of the Android emulator):
-    * Edit the IP address in [`MainActivity.kt`](https://github.com/OpenMined/AndroidWorker/blob/dev/app/src/main/java/com/mccorby/openmined/worker/ui/MainActivity.kt#L39) to match the IP address of the machine running the socket server
-    * Make the same edit to the IP address in [`network_security_config.xml`](https://github.com/OpenMined/AndroidWorker/blob/dev/app/src/main/res/xml/network_security_config.xml#L5)
-* Press the "Connect" button in the Android app    
+* Press the "Connect" button in the Android app
 * Start a Jupyter notebook and create a `WebsocketIOClientWorker` object.
   * Note that you need to provide strategies for serialization and compression
   * See the example [`Socket Bob.ipynb`](https://github.com/OpenMined/PyGrid/blob/dev/examples/android/Socket%20Bob.ipynb)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,6 +18,11 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         
         multiDexEnabled true
+
+        Properties properties = new Properties()
+        properties.load(project.rootProject.file("local_connection.properties").newDataInputStream())
+
+        buildConfigField "String", "websocketUrl", properties.getProperty("websocket_url", "")
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/mccorby/openmined/worker/ui/MainActivity.kt
+++ b/app/src/main/java/com/mccorby/openmined/worker/ui/MainActivity.kt
@@ -5,6 +5,7 @@ import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import androidx.work.WorkManager
+import com.mccorby.openmined.worker.BuildConfig
 import com.mccorby.openmined.worker.R
 import com.mccorby.openmined.worker.datasource.SyftWebSocketDataSource
 import com.mccorby.openmined.worker.domain.SyftOperand
@@ -36,7 +37,7 @@ class MainActivity : AppCompatActivity() {
     // TODO Inject using Kodein or another DI framework
     private fun injectDependencies() {
         val clientId = "Android-${System.currentTimeMillis()}"
-        val webSocketUrl = "http://10.0.2.2:5000"
+        val webSocketUrl = BuildConfig.websocketUrl
         val syftDataSource = SyftWebSocketDataSource(webSocketUrl, clientId)
         val syftRepository = SyftRepository(syftDataSource)
         val mlFramework = DL4JFramework()

--- a/app/src/main/java/com/mccorby/openmined/worker/ui/MainViewModel.kt
+++ b/app/src/main/java/com/mccorby/openmined/worker/ui/MainViewModel.kt
@@ -31,9 +31,15 @@ class MainViewModel(
 
     fun initiateCommunication() {
         val connectDisposable = connectUseCase.execute()
+            .doOnError {
+                viewState.postValue("Error connecting to socket.\n" +
+                        "Did you set websocket_url in local_connection.properties file?\n" +
+                        "Check also that the websocket is up and running")
+            }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe()
+
         compositeDisposable.add(connectDisposable)
 
         // TODO Ideally we should start listening to message when connectUseCase completes
@@ -49,6 +55,11 @@ class MainViewModel(
 
         val statusDisposable = syftRepository.onStatusChange()
             .map { viewState.postValue(it) }
+            .doOnError {
+                viewState.postValue("Error connecting to socket.\n" +
+                        "Did you set websocket_url in local_connection.properties file?\n" +
+                        "Check also that the websocket is up and running")
+            }
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe()

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,3 @@
 <network-security-config>
-
-    <!-- Temporarily added in order to support cleartext targeting Android P -->
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">10.0.2.2</domain>
-    </domain-config>
+    <base-config cleartextTrafficPermitted="true"/>
 </network-security-config>

--- a/local_connection.properties
+++ b/local_connection.properties
@@ -1,0 +1,2 @@
+# Set here the websocket url this app will connect to.
+websocket_url="http://10.0.2.2:5000"


### PR DESCRIPTION
Connection details must now be provided by the user.
By using a local file, we avoid having a hard-coded address for the websocket

Closes #30